### PR TITLE
fix(src): use github.token fallback when GH_TOKEN unavailable in Dependabot runs

### DIFF
--- a/.github/workflows/auto-commit.yml
+++ b/.github/workflows/auto-commit.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || github.token }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -20,7 +20,7 @@ jobs:
         id: create_pr
         uses: repo-sync/pull-request@v2
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN || github.token }}
           destination_branch: 'main'
           source_branch: ''
           pr_title: '${{ steps.branch_name.outputs.branch }}'
@@ -42,7 +42,7 @@ jobs:
         if: steps.create_pr.outputs.pr_number
         id: get_pr_id
         run: |
-          PR_DATA=$(curl -s -H "Authorization: token ${{ secrets.GH_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs.pr_number }}")
+          PR_DATA=$(curl -s -H "Authorization: token ${{ secrets.GH_TOKEN || github.token }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs.pr_number }}")
           PR_ID=$(echo "$PR_DATA" | jq -r '.node_id')
           echo "node_id=$PR_ID" >> "$GITHUB_OUTPUT"
 
@@ -50,7 +50,7 @@ jobs:
         if: steps.create_pr.outputs.pr_number
         run: |
           RESPONSE=$(curl -s -X POST \
-            -H "Authorization: bearer ${{ secrets.GH_TOKEN }}" \
+            -H "Authorization: bearer ${{ secrets.GH_TOKEN || github.token }}" \
             -H "Content-Type: application/json" \
             -d '{
               "query": "mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id }) { clientMutationId } }",

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   create_and_enable_automerge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/empty-format-test-job.yml
+++ b/.github/workflows/empty-format-test-job.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || github.token }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20


### PR DESCRIPTION
Use `${{ secrets.GH_TOKEN || github.token }}` fallback in checkout and PR creation steps so workflows succeed when Dependabot push events restrict access to repository secrets.

- close #132