### PR TITLE
build(deps-dev): bump lodash-es from 4.17.23 to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7736,9 +7736,9 @@
       "dev": true
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Bumps lodash-es from 4.17.23 to 4.18.1 to pick up security fixes.

## Security fixes

- `_.unset` / `_.omit`: Fixed prototype pollution via `constructor`/`prototype` path traversal (GHSA-f23m-r3pf-42rh)
- `_.template`: Fixed code injection via `imports` keys (GHSA-r5fr-rjxr-66jc, CVE-2026-4800)
- `template` / `fromPairs` ReferenceError bug fix (4.18.1 patch)

- close #135