### PR TITLE
chore(core): Add .cdp-tools/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ reports
 *.rej
 *.diff
 tmp
+.cdp-tools/


### PR DESCRIPTION
## Summary
- Add `.cdp-tools/` to `.gitignore` to prevent accidental commits of MCP debugger/browser tool artifacts
- The `.cdp-tools/` directory is auto-created by cdp-tools MCP tools during development sessions and should never be committed

## Test plan
- [x] Verified `.cdp-tools/` entry is added to `.gitignore`
- [x] All CI checks pass (lint, format, test)

- close #133